### PR TITLE
Voting with Emergency Pause Smart Contract (Clarity)

### DIFF
--- a/crispy_contracts/Clarinet.toml
+++ b/crispy_contracts/Clarinet.toml
@@ -14,6 +14,11 @@ epoch = 2.5
 path = 'contracts/storage_with_price_oracle_update.clar'
 clarity_version = 2
 epoch = 2.5
+
+[contracts.voting_with_emergency_pause]
+path = 'contracts/voting_with_emergency_pause.clar'
+clarity_version = 2
+epoch = 2.5
 [repl.analysis]
 passes = ['check_checker']
 

--- a/crispy_contracts/contracts/voting_with_emergency_pause.clar
+++ b/crispy_contracts/contracts/voting_with_emergency_pause.clar
@@ -1,0 +1,411 @@
+;; Enhanced Emergency Pause Voting Contract
+;; Advanced voting system with comprehensive features
+
+;; Error constants
+(define-constant ERR-UNAUTHORIZED (err u100))
+(define-constant ERR-VOTING-PAUSED (err u101))
+(define-constant ERR-ALREADY-VOTED (err u102))
+(define-constant ERR-INVALID-OPTION (err u103))
+(define-constant ERR-VOTING-NOT-PAUSED (err u104))
+(define-constant ERR-VOTING-NOT-STARTED (err u105))
+(define-constant ERR-VOTING-ENDED (err u106))
+(define-constant ERR-INVALID-DURATION (err u107))
+(define-constant ERR-PROPOSAL-NOT-FOUND (err u108))
+(define-constant ERR-PROPOSAL-ALREADY-EXISTS (err u109))
+(define-constant ERR-INSUFFICIENT-TOKENS (err u110))
+(define-constant ERR-BLACKLISTED (err u111))
+(define-constant ERR-PROPOSAL-NOT-ACTIVE (err u112))
+(define-constant ERR-MINIMUM-PARTICIPATION-NOT-MET (err u113))
+
+;; Contract owner/admin
+(define-constant CONTRACT-OWNER tx-sender)
+(define-constant MINIMUM-PARTICIPATION-THRESHOLD u10) ;; Minimum 10 votes for valid proposal
+
+;; Data variables
+(define-data-var voting-paused bool false)
+(define-data-var pause-reason (string-ascii 256) "")
+(define-data-var total-votes uint u0)
+(define-data-var current-proposal-id uint u0)
+(define-data-var voting-token-requirement uint u100) ;; Minimum tokens required to vote
+(define-data-var admin-count uint u1)
+
+;; Proposal structure
+(define-map proposals uint {
+  title: (string-ascii 256),
+  description: (string-ascii 1024),
+  creator: principal,
+  start-block: uint,
+  end-block: uint,
+  options: (list 10 (string-ascii 128)),
+  total-votes: uint,
+  is-active: bool,
+  min-participation: uint
+})
+
+;; Vote tracking
+(define-map votes {proposal-id: uint, voter: principal} uint)
+(define-map proposal-vote-counts {proposal-id: uint, option: uint} uint)
+(define-map user-voting-power principal uint)
+(define-map blacklisted-users principal bool)
+
+;; Admin management
+(define-map admins principal bool)
+
+;; Voting history and analytics
+(define-map user-vote-history principal (list 50 uint))
+(define-map proposal-voters uint (list 1000 principal))
+
+;; Helper functions
+(define-private (max-uint (a uint) (b uint))
+  (if (>= a b) a b)
+)
+
+;; Events/logs (using print for event logging)
+(define-private (log-event (event (string-ascii 64)) (data (string-ascii 256)))
+  (print {event: event, data: data, block-height: block-height})
+)
+
+;; Initialize contract
+(map-set admins CONTRACT-OWNER true)
+
+;; Read-only functions
+(define-read-only (is-voting-paused)
+  (var-get voting-paused)
+)
+
+(define-read-only (get-pause-reason)
+  (var-get pause-reason)
+)
+
+(define-read-only (is-admin (user principal))
+  (default-to false (map-get? admins user))
+)
+
+(define-read-only (get-proposal (proposal-id uint))
+  (map-get? proposals proposal-id)
+)
+
+(define-read-only (get-current-proposal-id)
+  (var-get current-proposal-id)
+)
+
+(define-read-only (get-user-vote (proposal-id uint) (user principal))
+  (map-get? votes {proposal-id: proposal-id, voter: user})
+)
+
+(define-read-only (get-proposal-vote-count (proposal-id uint) (option uint))
+  (default-to u0 (map-get? proposal-vote-counts {proposal-id: proposal-id, option: option}))
+)
+
+(define-read-only (get-voting-power (user principal))
+  (default-to u0 (map-get? user-voting-power user))
+)
+
+(define-read-only (is-blacklisted (user principal))
+  (default-to false (map-get? blacklisted-users user))
+)
+
+(define-read-only (has-user-voted (proposal-id uint) (user principal))
+  (is-some (map-get? votes {proposal-id: proposal-id, voter: user}))
+)
+
+(define-read-only (get-token-requirement)
+  (var-get voting-token-requirement)
+)
+
+(define-read-only (is-proposal-active (proposal-id uint))
+  (match (get-proposal proposal-id)
+    proposal 
+    (and 
+      (get is-active proposal)
+      (>= block-height (get start-block proposal))
+      (<= block-height (get end-block proposal))
+      (not (is-voting-paused))
+    )
+    false
+  )
+)
+
+(define-read-only (get-proposal-results (proposal-id uint))
+  (match (get-proposal proposal-id)
+    proposal
+    (some {
+      proposal-id: proposal-id,
+      title: (get title proposal),
+      total-votes: (get total-votes proposal),
+      option-1: (get-proposal-vote-count proposal-id u1),
+      option-2: (get-proposal-vote-count proposal-id u2),
+      option-3: (get-proposal-vote-count proposal-id u3),
+      option-4: (get-proposal-vote-count proposal-id u4),
+      option-5: (get-proposal-vote-count proposal-id u5),
+      is-active: (is-proposal-active proposal-id),
+      participation-met: (>= (get total-votes proposal) (get min-participation proposal))
+    })
+    none
+  )
+)
+
+;; Admin functions
+(define-public (add-admin (new-admin principal))
+  (begin
+    (asserts! (is-admin tx-sender) ERR-UNAUTHORIZED)
+    (map-set admins new-admin true)
+    (var-set admin-count (+ (var-get admin-count) u1))
+    (log-event "ADMIN_ADDED" "New admin added")
+    (ok true)
+  )
+)
+
+(define-public (remove-admin (admin principal))
+  (begin
+    (asserts! (is-admin tx-sender) ERR-UNAUTHORIZED)
+    (asserts! (not (is-eq admin CONTRACT-OWNER)) ERR-UNAUTHORIZED) ;; Cannot remove contract owner
+    (map-delete admins admin)
+    (var-set admin-count (- (var-get admin-count) u1))
+    (log-event "ADMIN_REMOVED" "Admin removed")
+    (ok true)
+  )
+)
+
+(define-public (pause-voting (reason (string-ascii 256)))
+  (begin
+    (asserts! (is-admin tx-sender) ERR-UNAUTHORIZED)
+    (asserts! (not (var-get voting-paused)) ERR-VOTING-PAUSED)
+    (var-set voting-paused true)
+    (var-set pause-reason reason)
+    (log-event "VOTING_PAUSED" reason)
+    (ok true)
+  )
+)
+
+(define-public (unpause-voting)
+  (begin
+    (asserts! (is-admin tx-sender) ERR-UNAUTHORIZED)
+    (asserts! (var-get voting-paused) ERR-VOTING-NOT-PAUSED)
+    (var-set voting-paused false)
+    (var-set pause-reason "")
+    (log-event "VOTING_UNPAUSED" "Voting resumed")
+    (ok true)
+  )
+)
+
+(define-public (set-token-requirement (new-requirement uint))
+  (begin
+    (asserts! (is-admin tx-sender) ERR-UNAUTHORIZED)
+    (var-set voting-token-requirement new-requirement)
+    (log-event "TOKEN_REQUIREMENT_UPDATED" "Token requirement changed")
+    (ok true)
+  )
+)
+
+(define-public (blacklist-user (user principal))
+  (begin
+    (asserts! (is-admin tx-sender) ERR-UNAUTHORIZED)
+    (map-set blacklisted-users user true)
+    (log-event "USER_BLACKLISTED" "User blacklisted")
+    (ok true)
+  )
+)
+
+(define-public (unblacklist-user (user principal))
+  (begin
+    (asserts! (is-admin tx-sender) ERR-UNAUTHORIZED)
+    (map-delete blacklisted-users user)
+    (log-event "USER_UNBLACKLISTED" "User unblacklisted")
+    (ok true)
+  )
+)
+
+(define-public (set-voting-power (user principal) (power uint))
+  (begin
+    (asserts! (is-admin tx-sender) ERR-UNAUTHORIZED)
+    (map-set user-voting-power user power)
+    (log-event "VOTING_POWER_SET" "User voting power updated")
+    (ok true)
+  )
+)
+
+;; Proposal management
+(define-public (create-proposal 
+  (title (string-ascii 256)) 
+  (description (string-ascii 1024))
+  (duration-blocks uint)
+  (options (list 10 (string-ascii 128)))
+  (min-participation uint)
+)
+  (let (
+    (proposal-id (+ (var-get current-proposal-id) u1))
+    (start-block (+ block-height u1))
+    (end-block (+ block-height duration-blocks))
+  )
+    (asserts! (> duration-blocks u0) ERR-INVALID-DURATION)
+    (asserts! (not (is-voting-paused)) ERR-VOTING-PAUSED)
+    (asserts! (not (is-blacklisted tx-sender)) ERR-BLACKLISTED)
+    
+    (map-set proposals proposal-id {
+      title: title,
+      description: description,
+      creator: tx-sender,
+      start-block: start-block,
+      end-block: end-block,
+      options: options,
+      total-votes: u0,
+      is-active: true,
+      min-participation: min-participation
+    })
+    
+    (var-set current-proposal-id proposal-id)
+    (log-event "PROPOSAL_CREATED" title)
+    (ok proposal-id)
+  )
+)
+
+(define-public (deactivate-proposal (proposal-id uint))
+  (let (
+    (proposal (unwrap! (get-proposal proposal-id) ERR-PROPOSAL-NOT-FOUND))
+  )
+    (asserts! (or (is-admin tx-sender) (is-eq tx-sender (get creator proposal))) ERR-UNAUTHORIZED)
+    
+    (map-set proposals proposal-id (merge proposal {is-active: false}))
+    (log-event "PROPOSAL_DEACTIVATED" "Proposal deactivated")
+    (ok true)
+  )
+)
+
+;; Enhanced voting functions
+(define-public (cast-vote (proposal-id uint) (option uint))
+  (let (
+    (voter tx-sender)
+    (proposal (unwrap! (get-proposal proposal-id) ERR-PROPOSAL-NOT-FOUND))
+    (current-count (get-proposal-vote-count proposal-id option))
+    (voter-power (max-uint u1 (get-voting-power voter)))
+  )
+    ;; Validation checks
+    (asserts! (is-proposal-active proposal-id) ERR-PROPOSAL-NOT-ACTIVE)
+    (asserts! (not (is-blacklisted voter)) ERR-BLACKLISTED)
+    (asserts! (not (has-user-voted proposal-id voter)) ERR-ALREADY-VOTED)
+    (asserts! (>= (get-voting-power voter) (var-get voting-token-requirement)) ERR-INSUFFICIENT-TOKENS)
+    (asserts! (and (>= option u1) (<= option u5)) ERR-INVALID-OPTION)
+    
+    ;; Record the vote
+    (map-set votes {proposal-id: proposal-id, voter: voter} option)
+    
+    ;; Update vote counts with voting power
+    (map-set proposal-vote-counts {proposal-id: proposal-id, option: option} (+ current-count voter-power))
+    
+    ;; Update proposal total votes
+    (map-set proposals proposal-id (merge proposal {total-votes: (+ (get total-votes proposal) voter-power)}))
+    
+    ;; Update global total
+    (var-set total-votes (+ (var-get total-votes) voter-power))
+    
+    ;; Add to voter list for this proposal
+    (let (
+      (current-voters (default-to (list) (map-get? proposal-voters proposal-id)))
+    )
+      (map-set proposal-voters proposal-id (unwrap! (as-max-len? (append current-voters voter) u1000) (ok option)))
+    )
+    
+    (log-event "VOTE_CAST" "Vote recorded")
+    (ok option)
+  )
+)
+
+(define-public (change-vote (proposal-id uint) (new-option uint))
+  (let (
+    (voter tx-sender)
+    (proposal (unwrap! (get-proposal proposal-id) ERR-PROPOSAL-NOT-FOUND))
+    (old-option (unwrap! (get-user-vote proposal-id voter) ERR-ALREADY-VOTED))
+    (old-count (get-proposal-vote-count proposal-id old-option))
+    (new-count (get-proposal-vote-count proposal-id new-option))
+    (voter-power (max-uint u1 (get-voting-power voter)))
+  )
+    ;; Validation checks
+    (asserts! (is-proposal-active proposal-id) ERR-PROPOSAL-NOT-ACTIVE)
+    (asserts! (not (is-blacklisted voter)) ERR-BLACKLISTED)
+    (asserts! (and (>= new-option u1) (<= new-option u5)) ERR-INVALID-OPTION)
+    
+    ;; Update vote record
+    (map-set votes {proposal-id: proposal-id, voter: voter} new-option)
+    
+    ;; Update vote counts
+    (map-set proposal-vote-counts {proposal-id: proposal-id, option: old-option} (- old-count voter-power))
+    (map-set proposal-vote-counts {proposal-id: proposal-id, option: new-option} (+ new-count voter-power))
+    
+    (log-event "VOTE_CHANGED" "Vote updated")
+    (ok new-option)
+  )
+)
+
+;; Batch operations
+(define-public (batch-set-voting-power (users (list 50 principal)) (powers (list 50 uint)))
+  (begin
+    (asserts! (is-admin tx-sender) ERR-UNAUTHORIZED)
+    (asserts! (is-eq (len users) (len powers)) ERR-INVALID-OPTION)
+    (ok (map set-user-power users powers))
+  )
+)
+
+(define-private (set-user-power (user principal) (power uint))
+  (begin
+    (map-set user-voting-power user power)
+    true
+  )
+)
+
+;; Analytics and reporting
+(define-read-only (get-voting-analytics)
+  {
+    total-proposals: (var-get current-proposal-id),
+    total-votes-cast: (var-get total-votes),
+    voting-paused: (is-voting-paused),
+    pause-reason: (var-get pause-reason),
+    token-requirement: (var-get voting-token-requirement),
+    admin-count: (var-get admin-count)
+  }
+)
+
+(define-read-only (get-user-stats (user principal))
+  {
+    voting-power: (get-voting-power user),
+    is-blacklisted: (is-blacklisted user),
+    is-admin: (is-admin user)
+  }
+)
+
+;; Emergency functions
+(define-public (emergency-reset-proposal (proposal-id uint))
+  (begin
+    (asserts! (is-admin tx-sender) ERR-UNAUTHORIZED)
+    (asserts! (var-get voting-paused) ERR-VOTING-NOT-PAUSED) ;; Only during emergency pause
+    
+    (let (
+      (proposal (unwrap! (get-proposal proposal-id) ERR-PROPOSAL-NOT-FOUND))
+    )
+      (map-set proposals proposal-id (merge proposal {
+        total-votes: u0,
+        is-active: false
+      }))
+      
+      ;; Clear vote counts (simplified - in production, you'd want to iterate through all options)
+      (map-delete proposal-vote-counts {proposal-id: proposal-id, option: u1})
+      (map-delete proposal-vote-counts {proposal-id: proposal-id, option: u2})
+      (map-delete proposal-vote-counts {proposal-id: proposal-id, option: u3})
+      (map-delete proposal-vote-counts {proposal-id: proposal-id, option: u4})
+      (map-delete proposal-vote-counts {proposal-id: proposal-id, option: u5})
+      
+      (log-event "EMERGENCY_RESET" "Proposal reset during emergency")
+      (ok true)
+    )
+  )
+)
+
+(define-public (emergency-shutdown)
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) ERR-UNAUTHORIZED)
+    (var-set voting-paused true)
+    (var-set pause-reason "EMERGENCY SHUTDOWN - CONTACT ADMIN")
+    (log-event "EMERGENCY_SHUTDOWN" "Contract emergency shutdown activated")
+    (ok true)
+  )
+)

--- a/crispy_contracts/tests/voting_with_emergency_pause.test.ts
+++ b/crispy_contracts/tests/voting_with_emergency_pause.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
# Enhanced Emergency Pause Voting Contract

## Overview

This smart contract implements a robust, permissioned voting system with emergency pause and admin controls. It supports proposal creation, multi-option voting, vote changing, vote weighting (voting power), blacklisting, batch operations, analytics, and emergency procedures (pause, reset, and shutdown).

The contract is designed for on-chain governance scenarios where administrators must be able to quickly pause voting during incidents and, if necessary, reset or shut down activity.

---

## Key Features

* Proposal creation with configurable duration and minimum participation.
* Multi-option voting (up to 5 options used by default checks) with vote weights (voting power).
* Admin role management (add/remove admins), with contract owner as the initial admin.
* Emergency controls: pause/unpause voting, emergency reset of proposals, emergency shutdown.
* Blacklist system to prevent specific principals from interacting with voting functions.
* Batch operations to set voting power for multiple users.
* Analytics and read-only helpers for governance dashboards.
* Event logging via `print` calls for off-chain monitoring.

---

## Notable Constants & Defaults

* `CONTRACT-OWNER`: contract deployer (admin by default).
* `MINIMUM-PARTICIPATION-THRESHOLD`: default minimum of 10 votes required for a valid proposal.
* `voting-token-requirement`: default `u100` tokens required to be eligible to vote (configurable by admin).

---

## Errors

The contract defines clear error constants to standardize failure modes:

* `ERR-UNAUTHORIZED` (u100) — caller lacks privileges.
* `ERR-VOTING-PAUSED` (u101) — voting is currently paused.
* `ERR-ALREADY-VOTED` (u102) — user already voted on the proposal.
* `ERR-INVALID-OPTION` (u103) — provided option is outside allowed range.
* `ERR-VOTING-NOT-PAUSED` (u104) — attempted operation only allowed during pause.
* `ERR-VOTING-NOT-STARTED` (u105) — voting window hasn’t begun.
* `ERR-VOTING-ENDED` (u106) — voting window already ended.
* `ERR-INVALID-DURATION` (u107) — proposal duration invalid.
* `ERR-PROPOSAL-NOT-FOUND` (u108) — proposal ID not found.
* `ERR-PROPOSAL-ALREADY-EXISTS` (u109) — duplicate proposal attempt.
* `ERR-INSUFFICIENT-TOKENS` (u110) — voter doesn’t meet token requirement.
* `ERR-BLACKLISTED` (u111) — user is blacklisted.
* `ERR-PROPOSAL-NOT-ACTIVE` (u112) — proposal not currently active.
* `ERR-MINIMUM-PARTICIPATION-NOT-MET` (u113) — proposal didn’t meet minimum participation.

---

## Storage Layout & Data Structures

* `voting-paused` (bool): whether voting is paused.
* `pause-reason` (string-ascii 256): explanation for pause.
* `total-votes` (uint): global count of votes cast (weighted by voting power).
* `current-proposal-id` (uint): latest proposal ID counter.
* `voting-token-requirement` (uint): min tokens required to vote.
* `admin-count` (uint): number of admins.

### Maps

* `proposals` (map uint → proposal struct): stores proposals with metadata (title, description, creator, start/end blocks, options list, total-votes, is-active, min-participation).
* `votes` (map {proposal-id, voter} → uint): specific vote of a user for a proposal.
* `proposal-vote-counts` (map {proposal-id, option} → uint): aggregated vote counts for each option.
* `user-voting-power` (map principal → uint): voting power for each user.
* `blacklisted-users` (map principal → bool): blacklist set.
* `admins` (map principal → bool): admin set.
* `user-vote-history` (map principal → list 50 uint): list of proposal IDs a user voted on.
* `proposal-voters` (map uint → list 1000 principal): list of voters for each proposal (used for simple tracking and analytics).

---

## Public Read-Only Functions

* `is-voting-paused()` — returns boolean pause state.
* `get-pause-reason()` — returns reason string.
* `is-admin(user)` — checks admin membership.
* `get-proposal(proposal-id)` — returns proposal struct if exists.
* `get-current-proposal-id()` — last created proposal id.
* `get-user-vote(proposal-id, user)` — vote value for a user.
* `get-proposal-vote-count(proposal-id, option)` — votes for a given option.
* `get-voting-power(user)` — returns user’s voting power.
* `is-blacklisted(user)` — blacklist status.
* `has-user-voted(proposal-id, user)` — whether a user has voted.
* `get-token-requirement()` — token threshold for voting.
* `is-proposal-active(proposal-id)` — whether a proposal is active now.
* `get-proposal-results(proposal-id)` — summary object of the proposal’s current state.
* `get-voting-analytics()` — returns global stats and configuration values.
* `get-user-stats(user)` — user-centric stats.

---

## Admin Functions

* `add-admin(new-admin)` — adds a new admin (caller must be an admin).
* `remove-admin(admin)` — removes an admin (cannot remove contract owner).
* `pause-voting(reason)` — pause all voting with a reason (admin-only).
* `unpause-voting()` — resume voting (admin-only).
* `set-token-requirement(new-requirement)` — change the minimum token requirement to vote.
* `blacklist-user(user)` / `unblacklist-user(user)` — manage blacklist.
* `set-voting-power(user, power)` — set a single user’s voting weight.
* `batch-set-voting-power(users, powers)` — set many users in one call (admin-only).

---

## Proposal Management

* `create-proposal(title, description, duration-blocks, options, min-participation)` — create a new proposal. Validates duration, pause state, and that the creator isn’t blacklisted. Proposal `start-block` is `block-height + 1` and `end-block` is `block-height + duration-blocks`.
* `deactivate-proposal(proposal-id)` — mark proposal inactive (admin or proposal creator).

---

## Voting Flow

* `cast-vote(proposal-id, option)` — casts a vote for a particular option. Validation includes: proposal active, user not blacklisted, user hasn’t already voted, user meets token requirement, and option is within allowed range. Vote is recorded in `votes`, `proposal-vote-counts` and `proposals[proposal-id].total-votes`. Global `total-votes` is also updated and `proposal-voters` list is appended.

* `change-vote(proposal-id, new-option)` — change an existing vote while the proposal remains active: adjusts option counts and vote record accordingly.

Notes: voting power is applied via `user-voting-power` (minimum of `1` is used through a private `max-uint` helper). The implementation assumes up to 5 options for validation checks; the options list stored in the proposal supports up to 10 entries.

---

## Emergency Functions

* `emergency-reset-proposal(proposal-id)` — admin-only and only allowed while voting is paused. Resets a proposal’s `total-votes` to zero and marks it inactive. Also clears vote counts for the first five option slots (simplified approach).

* `emergency-shutdown()` — owner-only emergency shutdown: sets `voting-paused` to `true` and writes an emergency pause reason. Intended for critical failures or security incidents.

---

## Events & Logging

The contract uses `log-event` (which internally calls `print`) to emit structured logs for off-chain listeners. Example events:

* `ADMIN_ADDED`, `ADMIN_REMOVED`
* `VOTING_PAUSED`, `VOTING_UNPAUSED`
* `TOKEN_REQUIREMENT_UPDATED`
* `USER_BLACKLISTED`, `USER_UNBLACKLISTED`
* `VOTING_POWER_SET`, `PROPOSAL_CREATED`, `PROPOSAL_DEACTIVATED`
* `VOTE_CAST`, `VOTE_CHANGED`
* `EMERGENCY_RESET`, `EMERGENCY_SHUTDOWN`

Off-chain systems should parse these prints to build dashboards and audit trails.

---

## Security Considerations & Recommendations

1. **Authority Model**: Admins have powerful privileges. Use multisig or governance checks off-chain when adding/removing admins or doing emergency shutdowns.
2. **Vote Reset Logic**: `emergency-reset-proposal` clears only five option counts and may leave other on-chain data (like `votes` map entries and `proposal-voters`) intact. A production-ready reset should carefully iterate and clear all related storage or migrate to an archival state to avoid inconsistent reads.
3. **Gas & Storage Costs**: `proposal-voters` stores up to 1000 principals per proposal; this can grow large and cost significant storage. Consider emitting events and maintaining off-chain voter lists instead of storing long arrays on-chain.
4. **Input Validation**: Ensure front-end or governance tooling enforces expected `options` length and `min-participation` semantics to avoid misconfigured proposals.
5. **Replay & Edge Cases**: Tests should include edge cases for block boundary conditions (`start-block`/`end-block`) and behavior during pause/unpause transitions.

---

## Testing Suggestions

* Unit test: creating proposals with valid/invalid durations and option lists.
* Unit test: casting votes with insufficient tokens, blacklisted users, repeated votes, and changing votes.
* Integration test: full lifecycle from proposal creation → voting → results, including meeting or failing the `min-participation` threshold.
* Emergency test: pause, emergency-reset-proposal, and emergency-shutdown flows.
* Gas/Storage test: simulate large `proposal-voters` lists to evaluate storage usage.

---

## Deployment Notes

* Initialize `voting-token-requirement`, `MINIMUM-PARTICIPATION-THRESHOLD`, and optionally seed `user-voting-power` for known accounts.
* Ensure the deploying account (contract owner) retains control or transfer ownership to a governance multisig before production use.

---

## Example Usage (pseudo)

```text
# Admin pauses voting
call pause-voting("Critical bug found")

# Owner or admin creates a proposal
call create-proposal("Upgrade network", "Upgrade to v2.0", u1000, ["yes","no"], u10)

# User casts a vote (if they meet token requirements)
call cast-vote(1, u1)

# Admin performs emergency reset while paused
call emergency-reset-proposal(1)
```

---

## License

MIT

---

## Contact / Maintainers

Maintainership is expected to be handled by the deployer and governance processes. Include contact details or a multisig address in your deployment documentation.
